### PR TITLE
Remove fast_finish flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
     - secure: "onTs0dEukjobvBFGPub4RppiwDdlSQGJbdbSE942w17J0JxCTm3JejKLd3Y/FDBflNks6V9vN0StLPrdyQc+qB0fhf3OAbJ/vdjrp0RNveeo+GBfGiXDKIdgLgDE1wWolAgSfadT+rOxyn9px4JDrmRin8T7LGIR3OZAt/ptfkM1GGDY2Heac95htsqLpjcLG9Pyw3cHbB6uiCoj3bD2+/pKB+ktXOKUQgCJVWIAF5Qf8IKJoiVl9oNwKnGJrQICe2EaXRsnI3c1fu5BivduklxuSSjVCLYzFddLPJSBiTNRfxnD/kONt3J0IOcUGFjFVXijTcsbAxzMBAsEDPe9tCuKYYNGZF63ZdtmY6PyY6dNsyZ2pHsuda8hpV+H4j1jQBcoXbwulsp3IaiWwq9ChL5Ysdf1VnqwJAxE2GQj4BbtFEVvaEFc3dV05XnWJKD9oTGoS/D6pkC33Wnp04gWpvv0tOgpybyqdIRbYbx9Ke7XU1VY1C5p7rIe8CfGY6lGeI9Cop5RCD+6ukAEMxtO9MWGV4FVWLd329CW+oGO4qNte/vuVpwBgdhsN/eXjIrpGb8RFnXg8EWr8H4ES6sy8uLG0lNWfkYQp+rjKIi6f5eXXGvuTvdjGi5moSCNfQCVgT3PUFphiiQUVvtuZbdW3Rk3wQMw8QCI/+EnTTuBi6g="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.6
       env:


### PR DESCRIPTION
It has been confirmed that the fast_finish flag is responsible for triggering multiple build notifications on #zftalk.dev.
